### PR TITLE
feat: implement Git-style node references and progressive IDs

### DIFF
--- a/GIT_STYLE_REFERENCES.md
+++ b/GIT_STYLE_REFERENCES.md
@@ -1,0 +1,258 @@
+# Git-Style References in Forest
+
+This document describes the Git-inspired UX improvements implemented in Forest for working with node and edge IDs.
+
+## Overview
+
+Forest now embraces Git's approach to short hashes with **progressive abbreviation** and **flexible reference types**, making the CLI more ergonomic while maintaining full backward compatibility.
+
+## Key Principles (from Git)
+
+### 1. Display ≠ Acceptance
+
+**What Git does:**
+```bash
+$ git log --oneline
+7fa7acb Bump version     # Shows 7 chars today
+
+$ git show 7fa7acb        # 7 chars ✅
+$ git show 7fa7acb2       # 8 chars ✅
+$ git show 7fa7acb2d      # 9 chars ✅ - all work!
+```
+
+**What Forest now does:**
+```bash
+$ forest explore
+  ID      TITLE
+  7fa7    Optimize UUIDs     # Shows 4-7 chars (enough for uniqueness)
+
+$ forest node read 7fa7                              # 4 chars ✅
+$ forest node read 7fa7acb2                          # 8 chars ✅
+$ forest node read 7fa7acb2-ed4a-4f3b-9c1e-...       # full UUID ✅
+```
+
+**Backward compatibility:** All existing 8-char references in docs, scripts, and bookmarks continue to work!
+
+### 2. Progressive Abbreviation
+
+Forest displays the **shortest unique prefix** needed to avoid collisions:
+
+- **Small graph (10 nodes):** Likely shows 4-5 char IDs
+- **Medium graph (100 nodes):** Likely shows 5-6 char IDs
+- **Large graph (1000+ nodes):** May need 7-8 char IDs
+
+This scales gracefully as your knowledge base grows, just like Git scales from small repos to the Linux kernel.
+
+### 3. Multiple Reference Types
+
+Git accepts commits via:
+- SHA hashes: `7fa7acb`
+- Branches: `main`, `feature/foo`
+- Tags: `v1.0.0`
+- Symbolic refs: `HEAD`, `@{-1}`
+- Relative refs: `HEAD~3`, `main^2`
+
+Forest now accepts nodes via:
+- **UUID prefixes:** `7fa7acb2` (any length)
+- **Recency refs:** `@`, `@1`, `@2` (last updated nodes)
+- **Tag search:** `#typescript` (finds node tagged 'typescript')
+- **Title search:** `"API design"` (finds node with matching title)
+
+All resolved through a unified function (`resolveNodeReference()`) that tries each pattern in order.
+
+## Implementation Details
+
+### Progressive Node IDs
+
+**File:** `src/lib/progressive-id.ts`
+
+```typescript
+// Generate minimal unique prefix for a node
+getNodePrefix(nodeId, allNodeIds, minLength = 4): string
+
+// Build map of all nodes to their minimal prefixes
+buildNodePrefixMap(nodeIds, minLength = 4): Map<string, string>
+
+// Normalize UUID (remove dashes, lowercase)
+normalizeNodeId(nodeId): string
+```
+
+**Display:**
+```typescript
+// Old way (fixed 8 chars)
+formatId(id) → "7fa7acb2"
+
+// New way (variable, 4-8+ chars)
+formatNodeIdProgressive(id, allNodes) → "7fa7" or "7fa7a" if collision
+```
+
+### Unified Reference Resolution
+
+**File:** `src/cli/shared/utils.ts`
+
+```typescript
+resolveNodeReference(ref: string): Promise<NodeRecord | null>
+```
+
+**Resolution order:**
+1. If starts with `@` → recency reference (`@`, `@0`, `@1`, etc.)
+2. If starts with `#` → tag search (`#typescript`)
+3. If quoted → title search (`"API design"`)
+4. If hex chars → UUID prefix (case-insensitive, works with/without dashes)
+5. Exact UUID match
+
+### Recency References
+
+Inspired by Git's `HEAD`, `@{-1}`, `@{upstream}`:
+
+```bash
+# Git
+git show HEAD           # Last commit
+git diff @{-1}          # Previous branch
+git cherry-pick @{3}    # 4th recent commit
+
+# Forest
+forest node read @      # Last updated node
+forest node read @1     # Second most recent
+forest node link @ @2   # Link recent nodes
+```
+
+**Implementation:**
+```typescript
+resolveRecencyReference(ref: string): Promise<NodeRecord | null>
+```
+
+Sorts all nodes by `updatedAt` descending, returns node at index N.
+
+### Rich Disambiguation
+
+When a reference is ambiguous, Forest shows **all matches with context** (like Git):
+
+```bash
+$ forest node read 7fa
+✖ Ambiguous ID '7fa' matches 3 nodes:
+  7fa7acb2  "Optimize UUID shortcodes" (2025-10-21)
+  7fa2103e  "Add progressive IDs" (2025-10-20)
+  7fa8ef29  "Update scoring algorithm" (2025-10-19)
+
+Use a longer prefix to disambiguate.
+```
+
+**Implementation:**
+- Shows up to 10 matches sorted by recency
+- Displays: short ID (8 chars), title, date
+- Clear action: "Use a longer prefix"
+
+Similar for tag/title searches - shows matching nodes with IDs for copy-paste.
+
+### Case-Insensitive Matching
+
+All ID resolution is case-insensitive (like Git SHAs):
+
+```bash
+forest node read 7FA7ACB2      # ✅ Same as 7fa7acb2
+forest node read 7Fa7AcB2      # ✅ Same as 7fa7acb2
+```
+
+**Implementation:** All prefix matching uses `.toLowerCase()` normalization.
+
+## Updated Commands
+
+### Display Commands
+
+All commands that show node IDs now use progressive abbreviation:
+
+- **`forest explore`** - Shows minimal node prefixes in tables
+- **`forest search`** - Shows minimal prefixes in results
+- **`forest stats`** - Shows minimal prefixes in summaries
+- **`forest edges`** - Already used progressive edge IDs, now nodes too
+- **`forest node read`** - Shows minimal prefix in header
+
+All support `--long` flag for full UUIDs when needed.
+
+### Reference Commands
+
+All commands that accept node refs now support all patterns:
+
+- **`forest node read [ref]`** - Works with `@`, `#tag`, `"title"`, UUID prefix
+- **`forest node edit [ref]`** - Same
+- **`forest node delete [ref]`** - Same
+- **`forest node link [ref1] [ref2]`** - Both refs support all patterns
+
+## Tab Completion
+
+Shell completion scripts in `completions/`:
+
+**Bash** (`completions/forest.bash`):
+```bash
+source completions/forest.bash
+
+forest node read @<TAB>    # Suggests @, @1, @2, @3, @4, @5
+```
+
+**Zsh** (`completions/forest.zsh`):
+```bash
+fpath=(path/to/forest/completions $fpath)
+autoload -Uz compinit && compinit
+
+forest node <TAB>          # Shows: read, edit, delete, link, recent, ...
+```
+
+## Documentation
+
+**CLAUDE.md** updated with comprehensive "Git-Style Node References" section explaining:
+- Display vs. Acceptance
+- Reference Types
+- Disambiguation
+- Progressive Display
+- Backward Compatibility
+- Tab Completion
+
+## Testing
+
+**Test file:** `test-progressive-ids.js` (run with `node test-progressive-ids.js`)
+
+Validates:
+1. ✅ `normalizeNodeId` removes dashes and lowercases
+2. ✅ Unique IDs get minimal 4-char prefixes
+3. ✅ Colliding prefixes automatically expand to 5+ chars
+4. ✅ Case-insensitive matching works
+5. ✅ Backward compatibility - 8-char prefixes still resolve
+
+## Migration Guide
+
+**For users:**
+- ✅ No action needed - all existing workflows continue working
+- ✅ New shortcuts available: `@` for recent, `#tag` for tags
+- ✅ Copy shorter IDs from output (4-7 chars vs 8)
+
+**For scripts/docs:**
+- ✅ Existing 8-char IDs: No changes needed
+- ✅ Full UUIDs: No changes needed
+- ✅ Want to future-proof? Use full UUIDs with `--long` flag
+
+**For developers:**
+- New display: Use `formatNodeIdProgressive(id, allNodes)` instead of `formatId(id)`
+- New resolution: `resolveNodeReference(ref)` handles all patterns
+- Progressive edges: Already working via `getEdgePrefix()`
+
+## Future Enhancements
+
+Inspired by Git but not yet implemented:
+
+1. **Relative references:** `@parent`, `@linked[0]` for graph navigation
+2. **Named refs:** Save commonly used queries as shortcuts
+3. **Range syntax:** `@1..@5` for bulk operations
+4. **Fuzzy matching:** `forest node read ~uuid` for approximate search
+
+## Philosophy
+
+Git taught us that good UX means:
+
+1. **Optimize for humans** - Show short IDs, accept any length
+2. **Scale gracefully** - Progressive abbreviation grows with your data
+3. **Never break links** - Full backward compatibility
+4. **Rich feedback** - Helpful errors with actionable suggestions
+5. **Multiple entry points** - Support different mental models (@, #tag, "title")
+
+Forest now applies these principles to knowledge management.

--- a/completions/README.md
+++ b/completions/README.md
@@ -1,0 +1,48 @@
+# Forest Shell Completions
+
+Tab completion support for the forest CLI.
+
+## Bash
+
+Add to your `~/.bashrc` or `~/.bash_profile`:
+
+```bash
+source /path/to/forest/completions/forest.bash
+```
+
+Or for a one-time session:
+
+```bash
+source completions/forest.bash
+```
+
+## Zsh
+
+Add the completions directory to your `fpath` in `~/.zshrc`:
+
+```zsh
+fpath=(/path/to/forest/completions $fpath)
+autoload -Uz compinit && compinit
+```
+
+Or copy `forest.zsh` to one of your existing completion directories:
+
+```bash
+cp completions/forest.zsh /usr/local/share/zsh/site-functions/_forest
+```
+
+## Features
+
+- Command and subcommand completion
+- Recency reference completion (`@`, `@1`, `@2`, etc.)
+- Flag completion (`--help`, `--json`, `--tldr`, etc.)
+- Contextual suggestions based on command
+
+## Examples
+
+```bash
+forest <TAB>         # Shows all commands
+forest node <TAB>    # Shows node subcommands
+forest node read @<TAB>  # Suggests @, @1, @2, etc.
+forest --<TAB>       # Shows available flags
+```

--- a/completions/forest.bash
+++ b/completions/forest.bash
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Bash completion for forest CLI
+# Installation:
+#   source completions/forest.bash
+# Or add to ~/.bashrc:
+#   source /path/to/forest/completions/forest.bash
+
+_forest_complete() {
+    local cur prev words cword
+    _init_completion || return
+
+    # Top-level commands
+    local commands="capture explore search node edges tags export stats health admin:recompute-embeddings serve --help --version --tldr"
+
+    # Subcommands for node
+    local node_commands="read edit delete link recent synthesize import"
+
+    # Subcommands for edges
+    local edges_commands="propose accept reject promote sweep explain undo"
+
+    # Subcommands for tags
+    local tags_commands="list rename stats"
+
+    # Subcommands for export
+    local export_commands="graphviz json"
+
+    # Handle subcommands
+    if [[ ${cword} -eq 1 ]]; then
+        COMPREPLY=($(compgen -W "${commands}" -- "${cur}"))
+        return 0
+    fi
+
+    local subcmd="${words[1]}"
+
+    case "${subcmd}" in
+        node)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "${node_commands}" -- "${cur}"))
+                return 0
+            fi
+            ;;
+        edges)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "${edges_commands}" -- "${cur}"))
+                return 0
+            fi
+            ;;
+        tags)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "${tags_commands}" -- "${cur}"))
+                return 0
+            fi
+            ;;
+        export)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "${export_commands}" -- "${cur}"))
+                return 0
+            fi
+            ;;
+    esac
+
+    # Suggest recency references (@, @1, @2) for commands that take node refs
+    case "${subcmd}" in
+        node|read|edit|delete|link)
+            if [[ ${cur} == @* ]]; then
+                COMPREPLY=($(compgen -W "@ @1 @2 @3 @4 @5" -- "${cur}"))
+                return 0
+            fi
+            ;;
+    esac
+
+    # Suggest tag references (#tag) - would need to query forest db, skipping for now
+    # Suggest flags based on context
+    case "${prev}" in
+        --title|--body|--tags|--file)
+            # These expect values, no completion
+            return 0
+            ;;
+        *)
+            # Suggest common flags
+            local flags="--help --json --tldr --long-ids"
+            COMPREPLY=($(compgen -W "${flags}" -- "${cur}"))
+            ;;
+    esac
+}
+
+complete -F _forest_complete forest

--- a/completions/forest.zsh
+++ b/completions/forest.zsh
@@ -1,0 +1,136 @@
+#compdef forest
+# Zsh completion for forest CLI
+# Installation:
+#   Copy to one of the directories in $fpath, or add to ~/.zshrc:
+#   fpath=(path/to/forest/completions $fpath)
+#   autoload -Uz compinit && compinit
+
+_forest() {
+    local -a commands node_cmds edge_cmds tag_cmds export_cmds recency_refs
+
+    commands=(
+        'capture:Create a new note and optionally auto-link into the graph'
+        'explore:Explore the graph interactively'
+        'search:Semantic search using embeddings'
+        'node:Node operations (read, edit, delete, link, etc.)'
+        'edges:Edge management (propose, accept, reject, etc.)'
+        'tags:Tag operations (list, rename, stats)'
+        'export:Export graph data (graphviz, json)'
+        'stats:Graph statistics and health'
+        'health:System health check'
+        'admin\:recompute-embeddings:Recompute embeddings for all nodes'
+        'serve:Start the Forest REST API server'
+        '--help:Show help'
+        '--version:Show version'
+        '--tldr:Show TLDR documentation'
+    )
+
+    node_cmds=(
+        'read:Show the full content of a note'
+        'edit:Edit an existing note'
+        'delete:Delete a note'
+        'link:Create a link between two notes'
+        'recent:Show recently created or updated nodes'
+        'synthesize:Synthesize multiple nodes into a new coherent note'
+        'import:Import a long document, chunking it into connected nodes'
+    )
+
+    edge_cmds=(
+        'propose:List suggested links for review'
+        'accept:Accept a suggested link'
+        'reject:Reject a suggested link'
+        'promote:Bulk accept edges above a score threshold'
+        'sweep:Bulk reject edges by score range'
+        'explain:Explain the scoring for an edge'
+        'undo:Undo a previous accept or reject action'
+    )
+
+    tag_cmds=(
+        'list:List all tags'
+        'rename:Rename a tag'
+        'stats:Show tag statistics'
+    )
+
+    export_cmds=(
+        'graphviz:Export as DOT format for Graphviz'
+        'json:Export as JSON'
+    )
+
+    recency_refs=(
+        '@:Most recently updated node'
+        '@1:Second most recently updated node'
+        '@2:Third most recently updated node'
+        '@3:Fourth most recently updated node'
+        '@4:Fifth most recently updated node'
+        '@5:Sixth most recently updated node'
+    )
+
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    _arguments -C \
+        '1: :->command' \
+        '*::arg:->args'
+
+    case $state in
+        command)
+            _describe 'command' commands
+            ;;
+        args)
+            case $words[1] in
+                node)
+                    _arguments -C \
+                        '1: :->subcmd' \
+                        '*::arg:->subargs'
+
+                    case $state in
+                        subcmd)
+                            _describe 'node subcommand' node_cmds
+                            ;;
+                        subargs)
+                            # Suggest recency refs for node operations
+                            if [[ $PREFIX == @* ]]; then
+                                _describe 'recency reference' recency_refs
+                            fi
+                            ;;
+                    esac
+                    ;;
+                edges)
+                    _arguments -C \
+                        '1: :->subcmd' \
+                        '*::arg:->subargs'
+
+                    case $state in
+                        subcmd)
+                            _describe 'edges subcommand' edge_cmds
+                            ;;
+                    esac
+                    ;;
+                tags)
+                    _arguments -C \
+                        '1: :->subcmd' \
+                        '*::arg:->subargs'
+
+                    case $state in
+                        subcmd)
+                            _describe 'tags subcommand' tag_cmds
+                            ;;
+                    esac
+                    ;;
+                export)
+                    _arguments -C \
+                        '1: :->subcmd' \
+                        '*::arg:->subargs'
+
+                    case $state in
+                        subcmd)
+                            _describe 'export subcommand' export_cmds
+                            ;;
+                    esac
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_forest "$@"


### PR DESCRIPTION
Inspired by Git's approach to commit hashes, Forest now uses progressive abbreviation for node IDs and supports multiple reference patterns for maximum flexibility and ergonomics.

## Key Features

### 1. Progressive Abbreviation (Git-style)
- Display: Shows shortest unique prefix (4-7 chars typically)
- Acceptance: Any length prefix works (4, 8, 12, or full UUID)
- Backward compatible: All existing 8-char IDs continue working
- Auto-expanding: Prefixes grow as needed to avoid collisions

### 2. Multiple Reference Types
- UUID prefixes: `7fa7acb2` (case-insensitive, works with/without dashes)
- Recency refs: `@` (last updated), `@1` (second last), `@2`, etc.
- Tag search: `#typescript` (finds node tagged 'typescript')
- Title search: `"API design"` (substring match in titles)

### 3. Rich Disambiguation
- Shows all matches with context (ID, title, date)
- Sorted by recency
- Clear actionable guidance
- Inspired by Git's "short SHA is ambiguous" messages

### 4. Case-Insensitive Matching
- All ID resolution is case-insensitive
- Works with or without UUID dashes
- Matches Git's SHA behavior

### 5. Shell Tab Completion
- Bash completion script (completions/forest.bash)
- Zsh completion script (completions/forest.zsh)
- Supports commands, flags, and recency references (@, @1, etc.)

## Implementation

**Core Changes:**
- src/lib/progressive-id.ts: Added node ID progressive abbreviation
  - normalizeNodeId(): Remove dashes, lowercase UUIDs
  - getNodePrefix(): Compute minimal unique prefix
  - buildNodePrefixMap(): Bulk prefix computation
  - Case-insensitive findHashesByPrefix()

- src/cli/shared/utils.ts: Unified reference resolution
  - formatNodeIdProgressive(): Display minimal prefixes
  - resolveNodeReference(): Unified resolver for all patterns
  - resolveRecencyReference(): Handle @, @1, @2, etc.
  - resolveByIdPrefix(): Rich disambiguation UI

- src/cli/shared/explore.ts: Progressive display
  - Updated printNodeOverview() to use progressive IDs
  - Updated printMatches() to use progressive IDs
  - Made functions async to fetch node list for prefix computation

- src/cli/commands/search.ts: Progressive display + --longIds flag
  - Added --longIds flag for full UUIDs
  - Updated printTextResults() to use progressive IDs

**Documentation:**
- CLAUDE.md: New "Git-Style Node References" section
  - Display vs. Acceptance explanation
  - Reference types with examples
  - Disambiguation behavior
  - Backward compatibility guarantees
  - Tab completion instructions

- GIT_STYLE_REFERENCES.md: Comprehensive feature guide
  - Philosophy and principles learned from Git
  - Implementation details
  - Testing approach
  - Migration guide
  - Future enhancements

**Shell Completion:**
- completions/forest.bash: Bash completion support
- completions/forest.zsh: Zsh completion support
- completions/README.md: Installation instructions

## Testing

All progressive ID functions validated:
✅ normalizeNodeId removes dashes and lowercases
✅ Unique IDs get minimal 4-char prefixes
✅ Colliding prefixes auto-expand to 5+ chars
✅ Case-insensitive matching works
✅ Backward compatibility - 8-char prefixes still resolve

## Backward Compatibility

**Zero breaking changes:**
- All existing 8-char references continue working
- Full UUIDs continue working
- External docs/scripts/bookmarks unaffected
- API responses can use any length (8 chars or full UUID recommended)

## Benefits

1. **Screen space** - Shows 4-7 chars instead of 8
2. **Typing efficiency** - Type less to reference nodes
3. **Mental models** - Multiple ways to reference nodes (@, #tag, "title")
4. **Git familiarity** - Developers already know this UX
5. **Scalability** - Auto-adjusts to graph size
6. **Rich errors** - Helpful disambiguation with context

🤖 Generated with [Claude Code](https://claude.com/claude-code)