### PR TITLE
Create configurable color scheme system. default to Forest palette

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,5 +1,6 @@
 import * as clack from '@clack/prompts';
 import { loadConfig, saveConfig, getConfigPath, type ForestConfig } from '../../lib/config';
+import { DEFAULT_COLOR_SCHEME, listColorSchemes } from '../../lib/color-schemes';
 
 type ClercModule = typeof import('clerc');
 
@@ -228,6 +229,23 @@ async function runConfigWizard() {
 
     newConfig.llmTaggerModel = llmModel;
   }
+
+  const colorScheme = (await clack.select({
+    message: 'Color scheme',
+    options: listColorSchemes().map(({ value, label, description }) => ({
+      value,
+      label,
+      hint: description,
+    })),
+    initialValue: currentConfig.colorScheme || DEFAULT_COLOR_SCHEME,
+  })) as ForestConfig['colorScheme'];
+
+  if (clack.isCancel(colorScheme)) {
+    clack.cancel('Configuration cancelled');
+    return;
+  }
+
+  newConfig.colorScheme = colorScheme;
 
   // Save config
   saveConfig(newConfig);

--- a/src/cli/formatters/edges.ts
+++ b/src/cli/formatters/edges.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import { EdgeRecord, NodeRecord } from '../../lib/db';
 import { formatId, getEdgePrefix } from '../shared/utils';
 import { colorize, makeHeaderColor, useColors } from './colors';
@@ -31,12 +30,12 @@ export type EdgeSuggestionsTableOptions = {
 /**
  * Format edge suggestions as a colorful table
  *
- * Uses Forest color themes for score components:
- * - ag (aggregate): Amber/bark brown
- * - em (embedding): Forest green
- * - tk (token): Moss/lime green
- * - ti (title): Autumn gold/yellow
- * - tg (tag): Clay red/rust
+ * Uses the active color scheme for score components:
+ * - ag (aggregate): main role
+ * - em (embedding): accent role
+ * - tk (token): highlight role
+ * - ti (title): emphasis role
+ * - tg (tag): warning role
  *
  * @param suggestions Array of edge suggestions with node data
  * @param options Formatting options
@@ -89,14 +88,14 @@ function formatEdgeSuggestionsHeader(): string {
 function formatEdgeSuggestionsColumnHeader(): string {
   return (
     '◌ ' +
-    chalk.grey('ref') + ' ' +
-    makeHeaderColor(35)('ag') + ' ' +
-    makeHeaderColor(120)('em') + ' ' +
-    makeHeaderColor(100)('tk') + ' ' +
-    makeHeaderColor(45)('ti') + ' ' +
-    makeHeaderColor(10)('tg') + '                                   ' +
+    colorize.label('ref') + ' ' +
+    makeHeaderColor('main')('ag') + ' ' +
+    makeHeaderColor('accent')('em') + ' ' +
+    makeHeaderColor('highlight')('tk') + ' ' +
+    makeHeaderColor('emphasis')('ti') + ' ' +
+    makeHeaderColor('warning')('tg') + '                                   ' +
     colorize.nodeA('nodeA') +
-    chalk.grey('::') +
+    colorize.grey('::') +
     colorize.nodeB('nodeB')
   );
 }

--- a/src/cli/formatters/index.ts
+++ b/src/cli/formatters/index.ts
@@ -20,7 +20,8 @@
 
 // Re-export color utilities
 export {
-  FOREST_THEMES,
+  ACTIVE_SCHEME,
+  COLOR_SCHEMES,
   hslToRgb,
   formatScoreComponent,
   colorizeScore,
@@ -29,6 +30,8 @@ export {
   useColors,
   colorize,
 } from './colors';
+
+export type { ColorRole, ColorSchemeName } from './colors';
 
 // Re-export edge formatters
 export {

--- a/src/lib/color-schemes.ts
+++ b/src/lib/color-schemes.ts
@@ -1,0 +1,139 @@
+export const COLOR_ROLES = [
+  'main',
+  'accent',
+  'highlight',
+  'emphasis',
+  'neutral',
+  'muted',
+  'success',
+  'warning',
+  'info',
+] as const;
+
+export type ColorRole = (typeof COLOR_ROLES)[number];
+
+export type ColorSchemeName =
+  | 'forest'
+  | 'catppuccin-mocha'
+  | 'dracula'
+  | 'nord'
+  | 'gruvbox-dark'
+  | 'solarized-dark';
+
+export interface ColorEntry {
+  hex: string;
+  name: string;
+}
+
+export interface ColorSchemeDefinition {
+  label: string;
+  description: string;
+  colors: Record<ColorRole, ColorEntry>;
+}
+
+export const COLOR_SCHEME_PRESETS: Record<ColorSchemeName, ColorSchemeDefinition> = {
+  forest: {
+    label: 'Forest',
+    description: 'Original Forest CLI palette inspired by autumn woods',
+    colors: {
+      main: { hex: '#d3893b', name: 'amber-bark' },
+      accent: { hex: '#4a7856', name: 'forest-pine' },
+      highlight: { hex: '#a8ddb5', name: 'sage-moss' },
+      emphasis: { hex: '#e3a652', name: 'autumn-gold' },
+      neutral: { hex: '#a8c5dd', name: 'misty-sky' },
+      muted: { hex: '#4b5a62', name: 'shadow-fir' },
+      success: { hex: '#7fb069', name: 'spruce-tip' },
+      warning: { hex: '#c75f3c', name: 'clay-rust' },
+      info: { hex: '#ff8c00', name: 'ember-glow' },
+    },
+  },
+  'catppuccin-mocha': {
+    label: 'Catppuccin (Mocha)',
+    description: 'Dreamy pastels with cozy contrast',
+    colors: {
+      main: { hex: '#b4befe', name: 'lavender' },
+      accent: { hex: '#f5c2e7', name: 'pink' },
+      highlight: { hex: '#94e2d5', name: 'teal' },
+      emphasis: { hex: '#f38ba8', name: 'rosewater' },
+      neutral: { hex: '#cdd6f4', name: 'text' },
+      muted: { hex: '#9399b2', name: 'subtext' },
+      success: { hex: '#a6e3a1', name: 'green' },
+      warning: { hex: '#f9e2af', name: 'peach' },
+      info: { hex: '#89dceb', name: 'sky' },
+    },
+  },
+  dracula: {
+    label: 'Dracula',
+    description: 'Bold neon lights on midnight base',
+    colors: {
+      main: { hex: '#bd93f9', name: 'purple' },
+      accent: { hex: '#ff79c6', name: 'pink' },
+      highlight: { hex: '#50fa7b', name: 'green' },
+      emphasis: { hex: '#ffb86c', name: 'orange' },
+      neutral: { hex: '#f8f8f2', name: 'text' },
+      muted: { hex: '#6272a4', name: 'comment' },
+      success: { hex: '#50fa7b', name: 'green' },
+      warning: { hex: '#ffb86c', name: 'orange' },
+      info: { hex: '#8be9fd', name: 'cyan' },
+    },
+  },
+  nord: {
+    label: 'Nord',
+    description: 'Arctic blues with warm aurora accents',
+    colors: {
+      main: { hex: '#88c0d0', name: 'frost' },
+      accent: { hex: '#a3be8c', name: 'aurora-green' },
+      highlight: { hex: '#b48ead', name: 'aurora-purple' },
+      emphasis: { hex: '#ebcb8b', name: 'aurora-gold' },
+      neutral: { hex: '#eceff4', name: 'snow' },
+      muted: { hex: '#4c566a', name: 'frost-muted' },
+      success: { hex: '#a3be8c', name: 'aurora-green' },
+      warning: { hex: '#d08770', name: 'aurora-orange' },
+      info: { hex: '#81a1c1', name: 'frost-blue' },
+    },
+  },
+  'gruvbox-dark': {
+    label: 'Gruvbox (Dark)',
+    description: 'Rustic warmth with vintage vibes',
+    colors: {
+      main: { hex: '#d3869b', name: 'purple' },
+      accent: { hex: '#83a598', name: 'aqua' },
+      highlight: { hex: '#b8bb26', name: 'green' },
+      emphasis: { hex: '#fabd2f', name: 'yellow' },
+      neutral: { hex: '#ebdbb2', name: 'light-text' },
+      muted: { hex: '#928374', name: 'muted' },
+      success: { hex: '#b8bb26', name: 'green' },
+      warning: { hex: '#fe8019', name: 'orange' },
+      info: { hex: '#83a598', name: 'aqua' },
+    },
+  },
+  'solarized-dark': {
+    label: 'Solarized (Dark)',
+    description: 'Classic solar spectrum for balanced contrast',
+    colors: {
+      main: { hex: '#268bd2', name: 'blue' },
+      accent: { hex: '#6c71c4', name: 'violet' },
+      highlight: { hex: '#2aa198', name: 'cyan' },
+      emphasis: { hex: '#b58900', name: 'yellow' },
+      neutral: { hex: '#eee8d5', name: 'base2' },
+      muted: { hex: '#839496', name: 'base0' },
+      success: { hex: '#859900', name: 'green' },
+      warning: { hex: '#cb4b16', name: 'orange' },
+      info: { hex: '#268bd2', name: 'blue' },
+    },
+  },
+};
+
+export const DEFAULT_COLOR_SCHEME: ColorSchemeName = 'forest';
+
+export function isColorSchemeName(value: unknown): value is ColorSchemeName {
+  return typeof value === 'string' && value in COLOR_SCHEME_PRESETS;
+}
+
+export function listColorSchemes(): Array<{ value: ColorSchemeName; label: string; description: string }> {
+  return Object.entries(COLOR_SCHEME_PRESETS).map(([value, scheme]) => ({
+    value: value as ColorSchemeName,
+    label: scheme.label,
+    description: scheme.description,
+  }));
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,6 +2,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
+import {
+  DEFAULT_COLOR_SCHEME,
+  isColorSchemeName,
+  type ColorSchemeName,
+} from './color-schemes';
+
 export interface ForestConfig {
   embedProvider?: 'local' | 'openai' | 'none';
   openaiApiKey?: string;
@@ -9,6 +15,7 @@ export interface ForestConfig {
   localModel?: string;
   taggingMethod?: 'lexical' | 'llm' | 'none';
   llmTaggerModel?: 'gpt-5-nano' | 'gpt-4o-mini' | 'gpt-4o';
+  colorScheme?: ColorSchemeName;
 }
 
 const CONFIG_FILE = path.join(os.homedir(), '.forestrc');
@@ -31,6 +38,13 @@ export function loadConfig(): ForestConfig {
   }
 
   // Merge with env vars (env vars take lower priority than file)
+  const schemeFromFile = isColorSchemeName((fileConfig as any).colorScheme)
+    ? ((fileConfig as any).colorScheme as ColorSchemeName)
+    : undefined;
+  const schemeFromEnv = isColorSchemeName(process.env.FOREST_COLOR_SCHEME)
+    ? (process.env.FOREST_COLOR_SCHEME as ColorSchemeName)
+    : undefined;
+
   const config: ForestConfig = {
     embedProvider: fileConfig.embedProvider || getEmbedProviderFromEnv(),
     openaiApiKey: fileConfig.openaiApiKey || process.env.OPENAI_API_KEY,
@@ -41,6 +55,7 @@ export function loadConfig(): ForestConfig {
     localModel: fileConfig.localModel || process.env.FOREST_EMBED_LOCAL_MODEL,
     taggingMethod: fileConfig.taggingMethod || 'lexical', // Default to lexical (backward compat)
     llmTaggerModel: fileConfig.llmTaggerModel || 'gpt-5-nano',
+    colorScheme: schemeFromFile || schemeFromEnv || DEFAULT_COLOR_SCHEME,
   };
 
   return config;


### PR DESCRIPTION
## Summary
- add a Forest preset that mirrors the original autumn-inspired CLI colors
- set the Forest preset as the default color scheme while keeping other presets available

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68f7f74d17a8832db34aeef256cb1fb5