### PR TITLE
Add HUD overlay windows for command palette and node detail

### DIFF
--- a/forest-desktop/package.json
+++ b/forest-desktop/package.json
@@ -17,6 +17,7 @@
     "@types/dagre": "^0.7.53",
     "@xyflow/react": "^12.9.0",
     "dagre": "^0.8.5",
+    "framer-motion": "^11.0.0",
     "lucide-react": "^0.292.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/forest-desktop/src/App.tsx
+++ b/forest-desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { GraphCanvas } from './components/GraphCanvas'
 import { CommandPalette } from './components/CommandPalette'
 import { NodeDetailPanel } from './components/NodeDetailPanel'
+import { HUDLayer } from './components/hud/HUDLayer'
 import { searchNodes } from './lib/tauri-commands'
 
 function App() {
@@ -26,11 +27,10 @@ function App() {
   }
 
   return (
-    <div className="app-container">
-      <GraphCanvas
-        onNodeClick={setSelectedNode}
-        highlightedNodes={highlightedNodes}
-      />
+    <HUDLayer>
+      <div className="app-container">
+        <GraphCanvas onNodeClick={setSelectedNode} highlightedNodes={highlightedNodes} />
+      </div>
 
       <CommandPalette
         onSearch={handleSearch}
@@ -39,30 +39,21 @@ function App() {
       />
 
       {selectedNode && (
-        <NodeDetailPanel
-          nodeId={selectedNode}
-          onClose={() => setSelectedNode(null)}
-        />
+        <NodeDetailPanel nodeId={selectedNode} onClose={() => setSelectedNode(null)} />
       )}
 
       {showSettings && (
-        <div style={{
-          position: 'fixed',
-          inset: 0,
-          background: 'rgba(0,0,0,0.5)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          zIndex: 1001,
-        }}>
-          <div style={{ background: 'white', padding: '2rem', borderRadius: '8px' }}>
+        <div className="app-settings-overlay">
+          <div className="app-settings-card">
             <h2>Settings</h2>
             <p>Settings panel coming soon!</p>
-            <button onClick={() => setShowSettings(false)}>Close</button>
+            <button onClick={() => setShowSettings(false)} className="forest-button">
+              Close
+            </button>
           </div>
         </div>
       )}
-    </div>
+    </HUDLayer>
   )
 }
 

--- a/forest-desktop/src/components/NodeDetailPanel.tsx
+++ b/forest-desktop/src/components/NodeDetailPanel.tsx
@@ -1,9 +1,123 @@
-import { useEffect, useState, useCallback } from 'react'
-import { getNode, getNodeConnections, updateNode, type NodeDetail, type NodeConnection } from '../lib/tauri-commands'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+import {
+  getNode,
+  getNodeConnections,
+  updateNode,
+  type NodeDetail,
+  type NodeConnection,
+} from '../lib/tauri-commands'
+import { HUDWindow, type HUDAnchor } from './hud/HUDWindow'
 
 interface Props {
   nodeId: string
   onClose: () => void
+}
+
+interface NodeDetailPanelContentProps {
+  node: NodeDetail
+  connections: NodeConnection[]
+  editing: boolean
+  saving: boolean
+  editTitle: string
+  editBody: string
+  onEditToggle: (editing: boolean) => void
+  onTitleChange: (value: string) => void
+  onBodyChange: (value: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+export function NodeDetailPanelContent({
+  node,
+  connections,
+  editing,
+  saving,
+  editTitle,
+  editBody,
+  onEditToggle,
+  onTitleChange,
+  onBodyChange,
+  onSave,
+  onCancel,
+}: NodeDetailPanelContentProps) {
+  return (
+    <div className="node-detail-panel">
+      <div className="node-detail-metadata">
+        <span>Created: {new Date(node.created_at).toLocaleString()}</span>
+        <span>Updated: {new Date(node.updated_at).toLocaleString()}</span>
+      </div>
+
+      {editing ? (
+        <textarea
+          value={editBody}
+          onChange={(event) => onBodyChange(event.target.value)}
+          className="node-detail-body-input"
+          placeholder="Add details..."
+        />
+      ) : (
+        <div className="node-detail-body">{node.body}</div>
+      )}
+
+      <div className="node-detail-actions">
+        {editing ? (
+          <>
+            <button type="button" onClick={onSave} disabled={saving} className="forest-button">
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            <button type="button" onClick={onCancel} disabled={saving} className="node-detail-secondary">
+              Cancel
+            </button>
+          </>
+        ) : (
+          <button type="button" onClick={() => onEditToggle(true)} className="forest-button">
+            Edit
+          </button>
+        )}
+      </div>
+
+      {node.tags.length > 0 && (
+        <div className="node-detail-tags">
+          {node.tags.map((tag) => (
+            <span key={tag} className="forest-tag">
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {connections.length > 0 && (
+        <div className="node-detail-connections">
+          <h3>Connected Notes ({connections.length})</h3>
+          {connections.map((connection) => (
+            <div key={connection.node_id} className="node-detail-connection">
+              <div className="node-detail-connection-title">{connection.title}</div>
+              <div className="node-detail-connection-score">{(connection.score * 100).toFixed(0)}%</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {editing && (
+        <div className="node-detail-edit-fields">
+          <label className="node-detail-edit-label" htmlFor="node-detail-title">
+            Title
+          </label>
+          <input
+            id="node-detail-title"
+            value={editTitle}
+            onChange={(event) => onTitleChange(event.target.value)}
+            className="node-detail-title-input"
+          />
+        </div>
+      )}
+    </div>
+  )
 }
 
 export function NodeDetailPanel({ nodeId, onClose }: Props) {
@@ -14,6 +128,12 @@ export function NodeDetailPanel({ nodeId, onClose }: Props) {
   const [editTitle, setEditTitle] = useState('')
   const [editBody, setEditBody] = useState('')
   const [saving, setSaving] = useState(false)
+  const initialPosition = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return { x: 0, y: 0 }
+    }
+    return { x: window.innerWidth - 420, y: window.innerHeight / 2 - 260 }
+  }, [])
 
   const loadNode = useCallback(async () => {
     try {
@@ -26,43 +146,20 @@ export function NodeDetailPanel({ nodeId, onClose }: Props) {
       setConnections(conns)
       setEditTitle(nodeData.title)
       setEditBody(nodeData.body)
-    } catch (err) {
-      console.error('Failed to load node:', err)
+    } catch (error) {
+      console.error('Failed to load node:', error)
     } finally {
       setLoading(false)
     }
   }, [nodeId])
-
-  const handleSave = async () => {
-    if (!node) return
-    try {
-      setSaving(true)
-      await updateNode(node.id, editTitle, editBody)
-      // Reload to get updated data
-      await loadNode()
-      setEditing(false)
-      console.log('Node updated successfully')
-    } catch (err) {
-      console.error('Failed to update node:', err)
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const handleCancelEdit = () => {
-    if (!node) return
-    setEditTitle(node.title)
-    setEditBody(node.body)
-    setEditing(false)
-  }
 
   useEffect(() => {
     loadNode()
   }, [loadNode])
 
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
         onClose()
       }
     }
@@ -70,165 +167,79 @@ export function NodeDetailPanel({ nodeId, onClose }: Props) {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
 
+  const handleSave = async () => {
+    if (!node) return
+    try {
+      setSaving(true)
+      await updateNode(node.id, editTitle, editBody)
+      await loadNode()
+      setEditing(false)
+    } catch (error) {
+      console.error('Failed to update node:', error)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const anchor = useMemo<HUDAnchor>(() => {
+    return {
+      getPosition: () => {
+        if (typeof document === 'undefined') return null
+        const element = document.querySelector<HTMLDivElement>(`.react-flow__node[data-id="${nodeId}"]`)
+        if (!element) return null
+        const rect = element.getBoundingClientRect()
+        return { x: rect.right, y: rect.top + rect.height / 2 }
+      },
+      offset: { x: 24, y: -220 },
+    }
+  }, [nodeId])
+
+  const header = useCallback(
+    ({ onPointerDown }: { onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void }) => (
+      <div className="node-detail-header" onPointerDown={onPointerDown}>
+        <h2>{node?.title ?? 'Loading…'}</h2>
+        <button type="button" onClick={onClose} className="node-detail-close" aria-label="Close node detail">
+          ×
+        </button>
+      </div>
+    ),
+    [node?.title, onClose]
+  )
+
   if (loading || !node) {
     return (
-      <div className="node-detail-panel">
-        <p>Loading...</p>
-      </div>
+      <HUDWindow id={`node-${nodeId}`} title="Node" isOpen initialPosition={initialPosition} followAnchor anchor={anchor}>
+        <div className="node-detail-loading">Loading…</div>
+      </HUDWindow>
     )
   }
 
   return (
-    <div
-      className="node-detail-panel"
-      style={{
-        position: 'fixed',
-        right: 0,
-        top: 0,
-        width: '400px',
-        height: '100vh',
-        background: 'white',
-        boxShadow: '-4px 0 12px rgba(0,0,0,0.1)',
-        padding: '2rem',
-        overflowY: 'auto',
-        animation: 'slideIn 0.3s ease-out',
-        zIndex: 900,
-      }}
+    <HUDWindow
+      id={`node-${nodeId}`}
+      isOpen
+      anchor={anchor}
+      followAnchor
+      initialPosition={initialPosition}
+      header={header}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-        {editing ? (
-          <input
-            type="text"
-            value={editTitle}
-            onChange={(e) => setEditTitle(e.target.value)}
-            style={{
-              fontSize: '1.5rem',
-              fontWeight: 'bold',
-              border: '2px solid #0066cc',
-              borderRadius: '4px',
-              padding: '0.25rem 0.5rem',
-              flex: 1,
-              marginRight: '0.5rem',
-            }}
-          />
-        ) : (
-          <h2 style={{ margin: 0 }}>{node.title}</h2>
-        )}
-        <button onClick={onClose} style={{ background: 'none', border: 'none', fontSize: '1.5rem', cursor: 'pointer' }}>
-          ×
-        </button>
-      </div>
-
-      {node.tags.length > 0 && (
-        <div style={{ marginBottom: '1rem' }}>
-          {node.tags.map((tag) => (
-            <span key={tag} className="forest-tag" style={{ marginRight: '0.5rem' }}>
-              #{tag}
-            </span>
-          ))}
-        </div>
-      )}
-
-      {editing ? (
-        <textarea
-          value={editBody}
-          onChange={(e) => setEditBody(e.target.value)}
-          style={{
-            width: '100%',
-            minHeight: '200px',
-            border: '2px solid #0066cc',
-            borderRadius: '4px',
-            padding: '0.5rem',
-            fontSize: '1rem',
-            lineHeight: '1.6',
-            fontFamily: 'inherit',
-            marginBottom: '1rem',
-            resize: 'vertical',
-          }}
-        />
-      ) : (
-        <div style={{ whiteSpace: 'pre-wrap', lineHeight: '1.6', marginBottom: '2rem' }}>
-          {node.body}
-        </div>
-      )}
-
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
-        {editing ? (
-          <>
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              style={{
-                padding: '0.5rem 1rem',
-                background: '#0066cc',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: saving ? 'not-allowed' : 'pointer',
-                opacity: saving ? 0.6 : 1,
-              }}
-            >
-              {saving ? 'Saving...' : 'Save'}
-            </button>
-            <button
-              onClick={handleCancelEdit}
-              disabled={saving}
-              style={{
-                padding: '0.5rem 1rem',
-                background: '#ddd',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: saving ? 'not-allowed' : 'pointer',
-              }}
-            >
-              Cancel
-            </button>
-          </>
-        ) : (
-          <button
-            onClick={() => setEditing(true)}
-            style={{
-              padding: '0.5rem 1rem',
-              background: '#0066cc',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-            }}
-          >
-            Edit
-          </button>
-        )}
-      </div>
-
-      <div style={{ fontSize: '0.85rem', color: '#666', marginBottom: '2rem' }}>
-        <p>Created: {new Date(node.created_at).toLocaleString()}</p>
-        <p>Updated: {new Date(node.updated_at).toLocaleString()}</p>
-      </div>
-
-      {connections.length > 0 && (
-        <div>
-          <h3>Connected Notes ({connections.length})</h3>
-          {connections.map((conn) => (
-            <div
-              key={conn.node_id}
-              style={{
-                padding: '0.75rem',
-                marginBottom: '0.5rem',
-                border: '1px solid #ddd',
-                borderRadius: '4px',
-              }}
-            >
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                <span>{conn.title}</span>
-                <span style={{ fontSize: '0.85rem', color: '#666' }}>
-                  {(conn.score * 100).toFixed(0)}%
-                </span>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+      <NodeDetailPanelContent
+        node={node}
+        connections={connections}
+        editing={editing}
+        saving={saving}
+        editTitle={editTitle}
+        editBody={editBody}
+        onEditToggle={setEditing}
+        onTitleChange={setEditTitle}
+        onBodyChange={setEditBody}
+        onSave={handleSave}
+        onCancel={() => {
+          setEditing(false)
+          setEditTitle(node.title)
+          setEditBody(node.body)
+        }}
+      />
+    </HUDWindow>
   )
 }

--- a/forest-desktop/src/components/hud/HUDLayer.tsx
+++ b/forest-desktop/src/components/hud/HUDLayer.tsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react'
+
+interface HUDContextValue {
+  container: HTMLDivElement | null
+  registerWindow: (id: string) => void
+  unregisterWindow: (id: string) => void
+  bringToFront: (id: string) => void
+  getZIndex: (id: string) => number
+  topmostId: string | null
+}
+
+const HUDContext = createContext<HUDContextValue | null>(null)
+
+export function useHUDLayer() {
+  const context = useContext(HUDContext)
+  if (!context) {
+    throw new Error('useHUDLayer must be used within a HUDLayer')
+  }
+  return context
+}
+
+interface HUDLayerProps {
+  children: ReactNode
+}
+
+const BASE_Z_INDEX = 1000
+
+export function HUDLayer({ children }: HUDLayerProps) {
+  const [container, setContainer] = useState<HTMLDivElement | null>(null)
+  const [stack, setStack] = useState<string[]>([])
+
+  const context = useMemo<HUDContextValue>(
+    () => ({
+      container,
+      registerWindow: (id: string) => {
+        setStack((prev) => (prev.includes(id) ? prev : [...prev, id]))
+      },
+      unregisterWindow: (id: string) => {
+        setStack((prev) => prev.filter((existing) => existing !== id))
+      },
+      bringToFront: (id: string) => {
+        setStack((prev) => {
+          if (!prev.includes(id)) return [...prev, id]
+          return [...prev.filter((existing) => existing !== id), id]
+        })
+      },
+      getZIndex: (id: string) => {
+        const index = stack.indexOf(id)
+        return index === -1 ? BASE_Z_INDEX : BASE_Z_INDEX + index + 1
+      },
+      topmostId: stack.length > 0 ? stack[stack.length - 1] : null,
+    }),
+    [container, stack]
+  )
+
+  return (
+    <HUDContext.Provider value={context}>
+      <div className="hud-host">
+        {children}
+        <div className="hud-layer" ref={setContainer} />
+      </div>
+    </HUDContext.Provider>
+  )
+}

--- a/forest-desktop/src/components/hud/HUDWindow.tsx
+++ b/forest-desktop/src/components/hud/HUDWindow.tsx
@@ -1,0 +1,146 @@
+import { createPortal } from 'react-dom'
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type ReactNode,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+import { motion, useDragControls, useSpring } from 'framer-motion'
+import { useHUDLayer } from './HUDLayer'
+
+export interface HUDAnchor {
+  getPosition: () => { x: number; y: number } | null
+  offset?: { x: number; y: number }
+}
+
+interface HUDWindowProps {
+  id?: string
+  title?: string
+  isOpen: boolean
+  initialPosition?: { x: number; y: number }
+  anchor?: HUDAnchor
+  followAnchor?: boolean
+  onClose?: () => void
+  children: ReactNode
+  className?: string
+  chrome?: boolean
+  header?: (utils: { onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void; isFocused: boolean }) => ReactNode
+}
+
+export function HUDWindow({
+  id,
+  title,
+  isOpen,
+  initialPosition,
+  anchor,
+  followAnchor = false,
+  onClose,
+  children,
+  className,
+  chrome = true,
+  header,
+}: HUDWindowProps) {
+  const generatedId = useId()
+  const windowId = id ?? generatedId
+  const hud = useHUDLayer()
+
+  const dragControls = useDragControls()
+  const [isDragging, setIsDragging] = useState(false)
+
+  useEffect(() => {
+    hud.registerWindow(windowId)
+    return () => hud.unregisterWindow(windowId)
+  }, [hud, windowId])
+
+  const zIndex = hud.getZIndex(windowId)
+  const isTopmost = hud.topmostId === windowId
+
+  const startingPosition = useMemo(() => {
+    if (initialPosition) return initialPosition
+    if (typeof window !== 'undefined') {
+      return { x: window.innerWidth / 2 - 200, y: window.innerHeight / 2 - 150 }
+    }
+    return { x: 0, y: 0 }
+  }, [initialPosition])
+
+  const x = useSpring(startingPosition.x, { stiffness: 300, damping: 30 })
+  const y = useSpring(startingPosition.y, { stiffness: 300, damping: 30 })
+  const scale = useSpring(isOpen ? 1 : 0.95, { stiffness: 250, damping: 25 })
+  const opacity = useSpring(isOpen ? 1 : 0, { stiffness: 200, damping: 25 })
+
+  useEffect(() => {
+    scale.set(isOpen ? 1 : 0.95)
+    opacity.set(isOpen ? 1 : 0)
+  }, [isOpen, opacity, scale])
+
+  useEffect(() => {
+    if (!anchor || !followAnchor || isDragging) return
+
+    let frame: number
+    const updatePosition = () => {
+      const next = anchor.getPosition()
+      if (next) {
+        const offset = anchor.offset ?? { x: 0, y: 0 }
+        x.set(next.x + offset.x)
+        y.set(next.y + offset.y)
+      }
+      frame = window.requestAnimationFrame(updatePosition)
+    }
+    frame = window.requestAnimationFrame(updatePosition)
+    return () => window.cancelAnimationFrame(frame)
+  }, [anchor, followAnchor, isDragging, x, y])
+
+  if (!hud.container) return null
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    hud.bringToFront(windowId)
+    if (chrome || header) {
+      dragControls.start(event.nativeEvent)
+    }
+  }
+
+  return createPortal(
+    <motion.div
+      role="dialog"
+      aria-modal="false"
+      initial={false}
+      animate={{}}
+      style={{
+        position: 'absolute',
+        x,
+        y,
+        scale,
+        opacity,
+        zIndex,
+        pointerEvents: isOpen ? 'auto' : 'none',
+      }}
+      drag
+      dragControls={dragControls}
+      dragListener={!chrome && !header}
+      dragMomentum
+      dragElastic={0.2}
+      onDragStart={() => setIsDragging(true)}
+      onDragEnd={() => setIsDragging(false)}
+      className={`hud-window${isTopmost ? ' hud-window--active' : ''}${className ? ` ${className}` : ''}`}
+      data-state={isOpen ? 'open' : 'closed'}
+      onPointerDown={() => hud.bringToFront(windowId)}
+    >
+      {header
+        ? header({ onPointerDown: handlePointerDown, isFocused: isTopmost })
+        : chrome && (
+            <div className="hud-window-header" onPointerDown={(event) => handlePointerDown(event)}>
+              <div className="hud-window-title">{title}</div>
+              {onClose && (
+                <button type="button" className="hud-window-close" onClick={onClose} aria-label="Close window">
+                  ×
+                </button>
+              )}
+            </div>
+          )}
+      <div className="hud-window-body">{children}</div>
+    </motion.div>,
+    hud.container
+  )
+}

--- a/forest-desktop/src/index.css
+++ b/forest-desktop/src/index.css
@@ -118,6 +118,7 @@ article {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
+  position: relative;
 }
 
 .command-palette-handle {
@@ -131,4 +132,310 @@ article {
   border-radius: 4px;
   font-size: 0.85rem;
   color: #666;
+}
+
+/* Heads-up display layer */
+.hud-host {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.hud-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+.hud-window {
+  pointer-events: auto;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 18px;
+  box-shadow: 0 22px 50px rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(18px) saturate(140%);
+  min-width: 320px;
+  max-width: 480px;
+  color: #1f2937;
+}
+
+.hud-window--active {
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.35);
+  border-color: rgba(99, 102, 241, 0.45);
+}
+
+.hud-window-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  cursor: grab;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.65));
+}
+
+.hud-window-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.hud-window-close {
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: #6b7280;
+  transition: color 0.2s ease;
+}
+
+.hud-window-close:hover {
+  color: #111827;
+}
+
+.hud-window-body {
+  padding: 1rem 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Command palette styling */
+.command-palette {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 360px;
+}
+
+.command-palette-collapsed {
+  border: 1px dashed rgba(99, 102, 241, 0.5);
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  color: #6366f1;
+  font-weight: 500;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.command-palette-collapsed:hover {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(79, 70, 229, 0.7);
+}
+
+.command-palette-form {
+  display: flex;
+}
+
+.command-palette-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 2px solid rgba(79, 70, 229, 0.45);
+  font-size: 1rem;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 12px 30px rgba(79, 70, 229, 0.15);
+}
+
+.command-palette-input:focus {
+  outline: none;
+  border-color: rgba(79, 70, 229, 0.75);
+  box-shadow: 0 18px 40px rgba(79, 70, 229, 0.25);
+}
+
+.command-palette-preview {
+  font-size: 0.85rem;
+  color: #4b5563;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(203, 213, 225, 0.6);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+}
+
+.command-palette-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.command-palette-secondary {
+  background: rgba(226, 232, 240, 0.85);
+  border: none;
+  border-radius: 10px;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: #475569;
+}
+
+.command-palette-secondary:hover {
+  background: rgba(203, 213, 225, 0.95);
+}
+
+/* Node detail panel styling */
+.node-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  cursor: grab;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(248, 250, 252, 0.7));
+}
+
+.node-detail-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.node-detail-close {
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  cursor: pointer;
+  color: #64748b;
+}
+
+.node-detail-close:hover {
+  color: #1f2937;
+}
+
+.node-detail-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.node-detail-metadata {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.node-detail-body {
+  white-space: pre-wrap;
+  line-height: 1.6;
+  color: #1f2937;
+}
+
+.node-detail-body-input {
+  width: 100%;
+  min-height: 200px;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 2px solid rgba(79, 70, 229, 0.45);
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.node-detail-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.node-detail-secondary {
+  background: rgba(226, 232, 240, 0.85);
+  border: none;
+  border-radius: 10px;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: #475569;
+}
+
+.node-detail-secondary:hover {
+  background: rgba(203, 213, 225, 0.95);
+}
+
+.node-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.node-detail-connections {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.node-detail-connection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(203, 213, 225, 0.8);
+  border-radius: 10px;
+  background: rgba(248, 250, 252, 0.95);
+}
+
+.node-detail-connection-title {
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.node-detail-connection-score {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.node-detail-edit-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.node-detail-edit-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.node-detail-title-input {
+  border-radius: 10px;
+  border: 2px solid rgba(79, 70, 229, 0.45);
+  padding: 0.6rem 0.8rem;
+  font-size: 1rem;
+}
+
+.node-detail-loading {
+  padding: 1rem;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+/* App overlays */
+.app-settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+  backdrop-filter: blur(8px);
+}
+
+.app-settings-card {
+  background: rgba(255, 255, 255, 0.95);
+  padding: 2rem;
+  border-radius: 16px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
+  min-width: 320px;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- add a reusable HUD layer and window shell with spring-driven dragging and z-order management
- wrap the command palette and node detail panel in the new HUD shell with presentational components and anchored motion
- refresh desktop styles to support stacked translucent windows and updated overlay polish

## Testing
- npm run build *(fails: repository dependencies are not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fbf4a6233c832d83c3fe74a52f4d1c