### PR TITLE
Add scene state machine with 3D viewport transitions

### DIFF
--- a/forest-desktop/package.json
+++ b/forest-desktop/package.json
@@ -12,11 +12,16 @@
     "release": "bun run tauri build"
   },
   "dependencies": {
+    "@react-three/drei": "^9.105.7",
+    "@react-three/fiber": "^8.16.1",
     "@tanstack/react-query": "^5.0.0",
     "@tauri-apps/api": "^2.9.0",
     "@types/dagre": "^0.7.53",
+    "@xstate/react": "^3.2.2",
     "@xyflow/react": "^12.9.0",
     "dagre": "^0.8.5",
+    "gsap": "^3.12.5",
+    "leva": "^0.9.48",
     "lucide-react": "^0.292.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -24,6 +29,8 @@
     "react-markdown": "^9.0.0",
     "reactflow": "^11.11.4",
     "remark-gfm": "^4.0.0",
+    "three": "^0.164.1",
+    "xstate": "^5.13.2",
     "zustand": "^4.4.0"
   },
   "devDependencies": {

--- a/forest-desktop/src/App.tsx
+++ b/forest-desktop/src/App.tsx
@@ -1,19 +1,31 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { GraphCanvas } from './components/GraphCanvas'
 import { CommandPalette } from './components/CommandPalette'
 import { NodeDetailPanel } from './components/NodeDetailPanel'
+import { GameViewport } from './components/GameViewport'
+import { SceneIntroOverlay } from './components/SceneIntroOverlay'
+import {
+  SceneStateProvider,
+  useSceneMode,
+  useSceneSend,
+  useSceneValue,
+} from './lib/sceneState'
 import { searchNodes } from './lib/tauri-commands'
 
-function App() {
+function AppContent() {
+  const send = useSceneSend()
+  const mode = useSceneMode()
+  const settingsOpen = useSceneValue((state) => state.context.settingsOpen)
   const [selectedNode, setSelectedNode] = useState<string | null>(null)
   const [highlightedNodes, setHighlightedNodes] = useState<string[]>([])
-  const [showSettings, setShowSettings] = useState(false)
+  const [reloadingGraph, setReloadingGraph] = useState(false)
 
   async function handleSearch(query: string) {
     try {
       const results = await searchNodes(query, 10)
       const nodeIds = results.map((r) => r.id)
       setHighlightedNodes(nodeIds)
+      send({ type: 'ENTER_EXPLORE' })
       console.log(`Search results: ${results.length} nodes found for "${query}"`)
     } catch (err) {
       console.error('Search failed:', err)
@@ -21,48 +33,94 @@ function App() {
   }
 
   function handleNodeCreated() {
-    // Reload graph
-    window.location.reload()
+    send({ type: 'ENTER_BUILD' })
+    setReloadingGraph(true)
+    // Give the backend a brief moment before reloading the graph dataset.
+    window.setTimeout(() => {
+      window.location.reload()
+    }, 400)
+  }
+
+  const hudClassName = useMemo(() => {
+    return ['hud-layer', `hud-layer--${mode}`].join(' ')
+  }, [mode])
+
+  useEffect(() => {
+    if (!reloadingGraph) return
+    const timeout = window.setTimeout(() => {
+      setReloadingGraph(false)
+      send({ type: 'ENTER_EXPLORE' })
+    }, 1200)
+    return () => window.clearTimeout(timeout)
+  }, [reloadingGraph, send])
+
+  const handleNodeClick = (nodeId: string) => {
+    setSelectedNode(nodeId)
+    send({ type: 'ENTER_FOCUS', nodeId })
+  }
+
+  const handleCloseNode = () => {
+    setSelectedNode(null)
+    send({ type: 'EXIT_FOCUS' })
+  }
+
+  const handlePaletteExpanded = (expanded: boolean) => {
+    send({ type: expanded ? 'OPEN_COMMAND' : 'CLOSE_COMMAND' })
+  }
+
+  const handleOpenSettings = () => {
+    send({ type: 'OPEN_SETTINGS' })
+  }
+
+  const handleCloseSettings = () => {
+    send({ type: 'CLOSE_SETTINGS' })
   }
 
   return (
-    <div className="app-container">
-      <GraphCanvas
-        onNodeClick={setSelectedNode}
-        highlightedNodes={highlightedNodes}
-      />
-
-      <CommandPalette
-        onSearch={handleSearch}
-        onNodeCreated={handleNodeCreated}
-        onOpenSettings={() => setShowSettings(true)}
-      />
-
-      {selectedNode && (
-        <NodeDetailPanel
-          nodeId={selectedNode}
-          onClose={() => setSelectedNode(null)}
+    <div className={`app-container scene-mode-${mode}`}>
+      <GameViewport />
+      <div className="graph-layer">
+        <GraphCanvas
+          onNodeClick={handleNodeClick}
+          highlightedNodes={highlightedNodes}
         />
-      )}
+      </div>
+      <SceneIntroOverlay />
+      <div className={hudClassName}>
+        <CommandPalette
+          onSearch={handleSearch}
+          onNodeCreated={handleNodeCreated}
+          onOpenSettings={handleOpenSettings}
+          onExpandedChange={handlePaletteExpanded}
+        />
 
-      {showSettings && (
-        <div style={{
-          position: 'fixed',
-          inset: 0,
-          background: 'rgba(0,0,0,0.5)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          zIndex: 1001,
-        }}>
-          <div style={{ background: 'white', padding: '2rem', borderRadius: '8px' }}>
+        {selectedNode && (
+          <div className="hud-window hud-window--detail">
+            <NodeDetailPanel nodeId={selectedNode} onClose={handleCloseNode} />
+          </div>
+        )}
+      </div>
+
+      {settingsOpen && (
+        <div className="hud-overlay">
+          <div className="hud-overlay__content">
             <h2>Settings</h2>
             <p>Settings panel coming soon!</p>
-            <button onClick={() => setShowSettings(false)}>Close</button>
+            <button className="forest-button" onClick={handleCloseSettings}>
+              Close
+            </button>
           </div>
         </div>
       )}
     </div>
+  )
+}
+
+function App() {
+  return (
+    <SceneStateProvider>
+      <AppContent />
+    </SceneStateProvider>
   )
 }
 

--- a/forest-desktop/src/components/CommandPalette.tsx
+++ b/forest-desktop/src/components/CommandPalette.tsx
@@ -6,13 +6,24 @@ interface Props {
   onSearch: (query: string) => void
   onNodeCreated: () => void
   onOpenSettings: () => void
+  onExpandedChange?: (expanded: boolean) => void
 }
 
-export function CommandPalette({ onSearch, onNodeCreated, onOpenSettings }: Props) {
+export function CommandPalette({
+  onSearch,
+  onNodeCreated,
+  onOpenSettings,
+  onExpandedChange,
+}: Props) {
   const [expanded, setExpanded] = useState(false)
   const [value, setValue] = useState('')
   const [creating, setCreating] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  const setExpandedState = (next: boolean) => {
+    setExpanded(next)
+    onExpandedChange?.(next)
+  }
 
   // Focus input when expanded
   useEffect(() => {
@@ -27,11 +38,11 @@ export function CommandPalette({ onSearch, onNodeCreated, onOpenSettings }: Prop
       // Cmd+K or Ctrl+K to focus
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault()
-        setExpanded(true)
+        setExpandedState(true)
       }
       // Esc to collapse
       if (e.key === 'Escape') {
-        setExpanded(false)
+        setExpandedState(false)
         setValue('')
       }
     }
@@ -49,16 +60,19 @@ export function CommandPalette({ onSearch, onNodeCreated, onOpenSettings }: Prop
         // Search command
         const query = value.slice(8).trim()
         onSearch(query)
+        setExpandedState(false)
         setValue('')
       } else if (value === '/settings') {
         // Settings command
         onOpenSettings()
+        setExpandedState(false)
         setValue('')
       } else {
         // Plain text = create node
         setCreating(true)
         await invoke('create_node_quick', { text: value })
         onNodeCreated()
+        setExpandedState(false)
         setValue('')
       }
     } catch (err) {
@@ -84,7 +98,7 @@ export function CommandPalette({ onSearch, onNodeCreated, onOpenSettings }: Prop
           {!expanded ? (
             <div
               className="command-palette-collapsed"
-              onClick={() => setExpanded(true)}
+              onClick={() => setExpandedState(true)}
               style={{
                 padding: '0.75rem 1.5rem',
                 background: 'rgba(255, 255, 255, 0.95)',

--- a/forest-desktop/src/components/GameViewport.tsx
+++ b/forest-desktop/src/components/GameViewport.tsx
@@ -1,0 +1,251 @@
+import { Canvas, useFrame, useThree } from '@react-three/fiber'
+import { Leva, useControls } from 'leva'
+import { useMemo, useRef } from 'react'
+import * as THREE from 'three'
+import {
+  useSceneEffect,
+  useSceneMode,
+  useSceneValue,
+  type SceneEffect,
+} from '../lib/sceneState'
+
+const backgroundColor = new THREE.Color('#020617')
+
+interface SceneContentsProps {
+  introProgress: number
+}
+
+export function GameViewport() {
+  const introProgress = useSceneValue((state) => state.context.introProgress)
+  const mode = useSceneMode()
+  const { fogNear, fogFar } = useControls('World Fog', {
+    fogNear: { value: 8, min: 1, max: 40, step: 1 },
+    fogFar: { value: 48, min: 20, max: 120, step: 1 },
+  })
+
+  const fogArgs = useMemo(() => [backgroundColor.clone(), fogNear, fogFar] as const, [fogNear, fogFar])
+
+  return (
+    <div className="viewport-layer" data-mode={mode} aria-hidden>
+      <Canvas
+        dpr={[1, 1.5]}
+        camera={{ position: [0, 4, 10], fov: 55, near: 0.1, far: 100 }}
+        style={{ pointerEvents: 'none' }}
+      >
+        <color attach="background" args={[backgroundColor]} />
+        <fog attach="fog" args={fogArgs} />
+        <SceneContents introProgress={introProgress} />
+      </Canvas>
+      <Leva collapsed />
+    </div>
+  )
+}
+
+function SceneContents({ introProgress }: SceneContentsProps) {
+  const fogPulse = useRef(introProgress)
+  fogPulse.current = introProgress
+  return (
+    <group>
+      <CameraRig introPulse={fogPulse} />
+      <ForestFloor />
+      <NodeEmphasis />
+      <RailMarkers />
+    </group>
+  )
+}
+
+function CameraRig({ introPulse }: { introPulse: React.MutableRefObject<number> }) {
+  const { scene } = useThree()
+  const targetPosition = useRef(new THREE.Vector3(0, 4, 10))
+  const targetLookAt = useRef(new THREE.Vector3(0, 0, 0))
+  const currentLookAt = useRef(new THREE.Vector3(0, 0, 0))
+  const ambientRef = useRef<THREE.AmbientLight>(null)
+  const keyLightRef = useRef<THREE.DirectionalLight>(null)
+  const backgroundTarget = useRef(backgroundColor.clone())
+  const focusTarget = useRef(0)
+  const focusAmount = useRef(0)
+  const { railResponse, lightResponse, focusResponse } = useControls('Camera Rails', {
+    railResponse: { value: 0.18, min: 0.02, max: 0.6, step: 0.01 },
+    lightResponse: { value: 0.2, min: 0.02, max: 0.6, step: 0.01 },
+    focusResponse: { value: 4, min: 1, max: 12, step: 0.25 },
+  })
+  const ambientTarget = useRef(0.4)
+  const keyTarget = useRef({ intensity: 0.5, color: new THREE.Color('#1d4ed8') })
+
+  useSceneEffect((effect: SceneEffect) => {
+    if (effect.type === 'camera.rail') {
+      targetPosition.current.fromArray(effect.target)
+      targetLookAt.current.fromArray(effect.lookAt)
+    }
+    if (effect.type === 'lighting.update') {
+      backgroundTarget.current = new THREE.Color(effect.color)
+      ambientTarget.current = effect.ambient
+      keyTarget.current = {
+        intensity: effect.intensity,
+        color: new THREE.Color(effect.color),
+      }
+    }
+    if (effect.type === 'node.focus') {
+      focusTarget.current = effect.nodeId ? 1 : 0
+    }
+    if (effect.type === 'timeline.progress' && effect.timeline === 'intro') {
+      focusTarget.current = Math.max(focusTarget.current, effect.progress * 0.6)
+    }
+  })
+
+  useFrame((state, delta) => {
+    const smoothing = 1 - Math.pow(1 - railResponse, delta * 60)
+    state.camera.position.lerp(targetPosition.current, smoothing)
+    currentLookAt.current.lerp(targetLookAt.current, smoothing)
+    state.camera.lookAt(currentLookAt.current)
+
+    const ambient = ambientRef.current
+    const key = keyLightRef.current
+    const lightSmoothing = 1 - Math.pow(1 - lightResponse, delta * 60)
+
+    if (ambient) {
+      ambient.intensity = THREE.MathUtils.lerp(
+        ambient.intensity,
+        ambientTarget.current + introPulse.current * 0.1,
+        lightSmoothing,
+      )
+    }
+
+    if (key) {
+      key.intensity = THREE.MathUtils.lerp(
+        key.intensity,
+        keyTarget.current.intensity + introPulse.current * 0.25,
+        lightSmoothing,
+      )
+      key.color.lerp(keyTarget.current.color, lightSmoothing)
+    }
+
+    if (scene.background instanceof THREE.Color) {
+      scene.background.lerp(backgroundTarget.current, lightSmoothing)
+    }
+
+    focusAmount.current = THREE.MathUtils.damp(
+      focusAmount.current,
+      focusTarget.current,
+      focusResponse,
+      delta,
+    )
+
+    const desiredFov = 55 - focusAmount.current * 8
+    if (Math.abs(state.camera.fov - desiredFov) > 0.01) {
+      state.camera.fov = THREE.MathUtils.lerp(state.camera.fov, desiredFov, smoothing)
+      state.camera.updateProjectionMatrix()
+    }
+  })
+
+  return (
+    <group>
+      <ambientLight ref={ambientRef} intensity={0.4} />
+      <directionalLight
+        ref={keyLightRef}
+        position={[6, 9, 4]}
+        intensity={0.5}
+        color={new THREE.Color('#1d4ed8')}
+        castShadow
+      />
+    </group>
+  )
+}
+
+function ForestFloor() {
+  return (
+    <group>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1.2, 0]} receiveShadow>
+        <planeGeometry args={[120, 120]} />
+        <meshStandardMaterial color="#020617" roughness={1} metalness={0} />
+      </mesh>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1.19, 0]} receiveShadow>
+        <planeGeometry args={[80, 80]} />
+        <meshStandardMaterial color="#0f172a" roughness={0.95} metalness={0.05} />
+      </mesh>
+    </group>
+  )
+}
+
+function NodeEmphasis() {
+  const meshRef = useRef<THREE.Mesh>(null)
+  const emissiveTarget = useRef(0)
+  const emissiveAmount = useRef(0)
+
+  useSceneEffect((effect) => {
+    if (effect.type === 'node.focus') {
+      emissiveTarget.current = effect.nodeId ? 1 : 0
+    }
+    if (effect.type === 'timeline.progress' && effect.timeline === 'intro') {
+      emissiveTarget.current = Math.max(emissiveTarget.current, effect.progress * 0.75)
+    }
+  })
+
+  useFrame((_, delta) => {
+    const mesh = meshRef.current
+    if (!mesh) return
+    const material = mesh.material as THREE.MeshStandardMaterial
+    emissiveAmount.current = THREE.MathUtils.damp(
+      emissiveAmount.current,
+      emissiveTarget.current,
+      5,
+      delta,
+    )
+    const scale = 1 + emissiveAmount.current * 0.4
+    mesh.scale.set(scale, scale, scale)
+    material.emissiveIntensity = 0.4 + emissiveAmount.current * 1.6
+  })
+
+  return (
+    <mesh ref={meshRef} position={[0, 1.3, 0]} castShadow>
+      <icosahedronGeometry args={[1.1, 2]} />
+      <meshStandardMaterial
+        color="#38bdf8"
+        emissive="#38bdf8"
+        metalness={0.25}
+        roughness={0.35}
+        emissiveIntensity={0.6}
+      />
+    </mesh>
+  )
+}
+
+function RailMarkers() {
+  const groupRef = useRef<THREE.Group>(null)
+  const mode = useSceneMode()
+  const wave = useRef(0)
+
+  useSceneEffect((effect) => {
+    if (effect.type === 'timeline.progress' && effect.timeline === 'loading') {
+      wave.current = effect.progress
+    }
+  })
+
+  useFrame((_, delta) => {
+    const group = groupRef.current
+    if (!group) return
+    const rotationSpeed = mode === 'intro' ? 0.6 : 0.25
+    group.rotation.y += rotationSpeed * delta
+    group.scale.setScalar(0.8 + Math.sin(wave.current * Math.PI) * 0.1)
+  })
+
+  return (
+    <group ref={groupRef} position={[0, 0.4, 0]}>
+      {[...Array(8)].map((_, index) => {
+        const angle = (index / 8) * Math.PI * 2
+        const radius = 6 + Math.sin(index * 1.3) * 0.8
+        return (
+          <mesh
+            key={index}
+            position={[Math.cos(angle) * radius, 0, Math.sin(angle) * radius]}
+            rotation={[-Math.PI / 2, 0, 0]}
+            receiveShadow
+          >
+            <ringGeometry args={[0.18, 0.22, 32]} />
+            <meshBasicMaterial color="#1e293b" />
+          </mesh>
+        )
+      })}
+    </group>
+  )
+}

--- a/forest-desktop/src/components/SceneIntroOverlay.tsx
+++ b/forest-desktop/src/components/SceneIntroOverlay.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react'
+import { useSceneMode, useSceneValue } from '../lib/sceneState'
+
+export function SceneIntroOverlay() {
+  const mode = useSceneMode()
+  const progress = useSceneValue((state) => state.context.introProgress)
+  const isVisible = mode === 'loading' || mode === 'intro'
+
+  const label = useMemo(() => {
+    if (mode === 'loading') {
+      return 'Warming up the forest OS...'
+    }
+    if (mode === 'intro') {
+      return 'Walking the canopy rails'
+    }
+    return ''
+  }, [mode])
+
+  if (!isVisible) {
+    return null
+  }
+
+  const opacity = mode === 'loading' ? 1 : Math.max(0, 1 - progress)
+
+  return (
+    <div className="scene-intro-overlay" style={{ opacity }}>
+      <div className="scene-intro-pulse" aria-hidden>
+        <div
+          className="scene-intro-progress"
+          style={{ transform: `scaleX(${Math.max(0.05, progress)})` }}
+        />
+      </div>
+      <p className="scene-intro-label">{label}</p>
+    </div>
+  )
+}

--- a/forest-desktop/src/index.css
+++ b/forest-desktop/src/index.css
@@ -118,6 +118,139 @@ article {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
+  position: relative;
+}
+
+.viewport-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.graph-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+}
+
+.hud-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  pointer-events: none;
+  transition: transform 420ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 420ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  padding: 2rem;
+}
+
+.hud-layer > * {
+  pointer-events: auto;
+}
+
+.hud-layer--command {
+  transform: translateY(12px) scale(1.02);
+}
+
+.hud-layer--focus {
+  transform: translateY(-8px);
+}
+
+.hud-layer--build {
+  transform: translateY(18px);
+}
+
+.hud-window {
+  margin-top: 2rem;
+  backdrop-filter: blur(10px);
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+  padding: 1.5rem;
+  max-width: min(420px, 60vw);
+  width: 100%;
+  color: #f8fafc;
+  transition: transform 360ms ease, opacity 360ms ease;
+}
+
+.hud-window--detail {
+  transform-origin: top center;
+}
+
+.hud-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 4;
+  background: rgba(2, 6, 23, 0.68);
+  backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn 260ms ease;
+}
+
+.hud-overlay__content {
+  background: rgba(15, 23, 42, 0.92);
+  color: #e2e8f0;
+  padding: 2rem;
+  border-radius: 18px;
+  min-width: 280px;
+  max-width: 420px;
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.scene-intro-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  padding-bottom: 4rem;
+  transition: opacity 360ms ease;
+}
+
+.scene-intro-pulse {
+  width: min(460px, 70vw);
+  height: 6px;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 999px;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.scene-intro-progress {
+  height: 100%;
+  width: 100%;
+  transform-origin: left;
+  background: linear-gradient(90deg, #38bdf8 0%, #a855f7 100%);
+  transition: transform 120ms ease-out;
+}
+
+.scene-intro-label {
+  margin-top: 1rem;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-shadow: 0 2px 12px rgba(2, 6, 23, 0.9);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .command-palette-handle {

--- a/forest-desktop/src/lib/sceneState.ts
+++ b/forest-desktop/src/lib/sceneState.ts
@@ -1,0 +1,417 @@
+import { createContext, useContext, useEffect, useMemo, useRef } from 'react'
+import { useInterpret, useSelector } from '@xstate/react'
+import { assign, createMachine, type InterpreterFrom, type StateFrom } from 'xstate'
+import { gsap } from 'gsap'
+
+export type SceneMode = 'loading' | 'intro' | 'explore' | 'focus' | 'command' | 'build'
+
+interface SceneContext {
+  activeNode: string | null
+  settingsOpen: boolean
+  introProgress: number
+}
+
+type SceneEvent =
+  | { type: 'BOOT_COMPLETE' }
+  | { type: 'INTRO_COMPLETE' }
+  | { type: 'SKIP_INTRO' }
+  | { type: 'ENTER_EXPLORE' }
+  | { type: 'ENTER_FOCUS'; nodeId?: string | null }
+  | { type: 'EXIT_FOCUS' }
+  | { type: 'ENTER_BUILD' }
+  | { type: 'OPEN_COMMAND' }
+  | { type: 'CLOSE_COMMAND' }
+  | { type: 'OPEN_SETTINGS' }
+  | { type: 'CLOSE_SETTINGS' }
+  | { type: 'RESET' }
+  | { type: 'TIMELINE_PROGRESS'; progress: number }
+
+const sceneMachine = createMachine<SceneContext, SceneEvent>(
+  {
+    id: 'scene-state',
+    predictableActionArguments: true,
+    initial: 'loading',
+    context: {
+      activeNode: null,
+      settingsOpen: false,
+      introProgress: 0,
+    },
+    states: {
+      loading: {
+        after: {
+          900: { target: 'intro' },
+        },
+        on: {
+          BOOT_COMPLETE: 'intro',
+          SKIP_INTRO: 'explore',
+        },
+        exit: 'resetIntroProgress',
+      },
+      intro: {
+        on: {
+          INTRO_COMPLETE: 'explore',
+          SKIP_INTRO: 'explore',
+        },
+      },
+      explore: {
+        on: {
+          ENTER_FOCUS: {
+            target: 'focus',
+            actions: 'setActiveNode',
+          },
+          OPEN_COMMAND: 'command',
+          ENTER_BUILD: 'build',
+        },
+      },
+      focus: {
+        on: {
+          ENTER_EXPLORE: {
+            target: 'explore',
+            actions: 'clearActiveNode',
+          },
+          EXIT_FOCUS: {
+            target: 'explore',
+            actions: 'clearActiveNode',
+          },
+          OPEN_COMMAND: 'command',
+        },
+      },
+      command: {
+        on: {
+          CLOSE_COMMAND: 'explore',
+          ENTER_FOCUS: {
+            target: 'focus',
+            actions: 'setActiveNode',
+          },
+          ENTER_BUILD: 'build',
+        },
+      },
+      build: {
+        on: {
+          ENTER_EXPLORE: 'explore',
+          OPEN_COMMAND: 'command',
+        },
+      },
+    },
+    on: {
+      RESET: {
+        target: 'loading',
+        actions: 'clearActiveNode',
+      },
+      OPEN_SETTINGS: {
+        actions: 'openSettings',
+      },
+      CLOSE_SETTINGS: {
+        actions: 'closeSettings',
+      },
+      TIMELINE_PROGRESS: {
+        actions: 'setIntroProgress',
+      },
+    },
+  },
+  {
+    actions: {
+      setActiveNode: assign((context, event) => {
+        if (event.type === 'ENTER_FOCUS') {
+          return { ...context, activeNode: event.nodeId ?? null }
+        }
+        return context
+      }),
+      clearActiveNode: assign((context) => ({ ...context, activeNode: null })),
+      openSettings: assign((context) => ({ ...context, settingsOpen: true })),
+      closeSettings: assign((context) => ({ ...context, settingsOpen: false })),
+      setIntroProgress: assign((context, event) => {
+        if (event.type === 'TIMELINE_PROGRESS') {
+          return { ...context, introProgress: event.progress }
+        }
+        return context
+      }),
+      resetIntroProgress: assign((context) => ({ ...context, introProgress: 0 })),
+    },
+  },
+)
+
+type SceneState = StateFrom<typeof sceneMachine>
+export type SceneService = InterpreterFrom<typeof sceneMachine>
+
+export type SceneEffect =
+  | { type: 'mode.enter'; mode: SceneMode }
+  | { type: 'mode.exit'; mode: SceneMode }
+  | { type: 'camera.rail'; mode: SceneMode; target: [number, number, number]; lookAt: [number, number, number]; duration: number }
+  | { type: 'lighting.update'; mode: SceneMode; ambient: number; intensity: number; color: string }
+  | { type: 'hud.animate'; mode: SceneMode; commandOpen: boolean; settingsOpen: boolean }
+  | { type: 'node.focus'; nodeId: string | null }
+  | { type: 'timeline.progress'; timeline: 'loading' | 'intro'; progress: number }
+
+type SceneEffectListener = (effect: SceneEffect) => void
+
+const listeners = new Set<SceneEffectListener>()
+
+function emitSceneEffect(effect: SceneEffect) {
+  listeners.forEach((listener) => listener(effect))
+}
+
+export function onSceneEffect(listener: SceneEffectListener) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+const sceneRails: Record<SceneMode, {
+  position: [number, number, number]
+  lookAt: [number, number, number]
+  ambient: number
+  intensity: number
+  color: string
+  duration: number
+}> = {
+  loading: {
+    position: [0, 6, 16],
+    lookAt: [0, 0, 0],
+    ambient: 0.4,
+    intensity: 0.2,
+    color: '#0f172a',
+    duration: 1.8,
+  },
+  intro: {
+    position: [0, 4, 10],
+    lookAt: [0, 0, 0],
+    ambient: 0.6,
+    intensity: 0.35,
+    color: '#172554',
+    duration: 1.2,
+  },
+  explore: {
+    position: [2, 5, 8],
+    lookAt: [0, 0, 0],
+    ambient: 0.75,
+    intensity: 0.45,
+    color: '#0f766e',
+    duration: 0.9,
+  },
+  focus: {
+    position: [1.5, 3.2, 5.2],
+    lookAt: [0, 0, 0],
+    ambient: 0.55,
+    intensity: 0.55,
+    color: '#7c3aed',
+    duration: 0.7,
+  },
+  command: {
+    position: [-1.5, 4, 7.5],
+    lookAt: [0, 0, 0],
+    ambient: 0.65,
+    intensity: 0.4,
+    color: '#1d4ed8',
+    duration: 0.8,
+  },
+  build: {
+    position: [0, 6, 12],
+    lookAt: [0, 0, 0],
+    ambient: 0.8,
+    intensity: 0.6,
+    color: '#f59e0b',
+    duration: 0.85,
+  },
+}
+
+const SceneStateContext = createContext<SceneService | null>(null)
+
+function resolveSceneMode(state: SceneState): SceneMode {
+  const value = state.value
+  if (typeof value === 'string') {
+    return value as SceneMode
+  }
+  return 'explore'
+}
+
+function useSceneMachineEffects(service: SceneService) {
+  const previousModeRef = useRef<SceneMode | null>(null)
+  const previousNodeRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const subscription = service.subscribe((state) => {
+      const mode = resolveSceneMode(state)
+      const previousMode = previousModeRef.current
+
+      if (previousMode && previousMode !== mode) {
+        emitSceneEffect({ type: 'mode.exit', mode: previousMode })
+      }
+
+      if (!previousMode || previousMode !== mode) {
+        emitSceneEffect({ type: 'mode.enter', mode })
+        const rail = sceneRails[mode]
+        emitSceneEffect({
+          type: 'camera.rail',
+          mode,
+          target: rail.position,
+          lookAt: rail.lookAt,
+          duration: rail.duration,
+        })
+        emitSceneEffect({
+          type: 'lighting.update',
+          mode,
+          ambient: rail.ambient,
+          intensity: rail.intensity,
+          color: rail.color,
+        })
+        previousModeRef.current = mode
+        if (typeof document !== 'undefined') {
+          document.documentElement.style.setProperty('--scene-mode', mode)
+        }
+      }
+
+      emitSceneEffect({
+        type: 'hud.animate',
+        mode,
+        commandOpen: state.matches('command'),
+        settingsOpen: state.context.settingsOpen,
+      })
+
+      if (previousNodeRef.current !== state.context.activeNode) {
+        previousNodeRef.current = state.context.activeNode
+        emitSceneEffect({ type: 'node.focus', nodeId: state.context.activeNode })
+      }
+    })
+
+    return () => subscription.unsubscribe()
+  }, [service])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const timeline = gsap.timeline({ paused: true })
+    const proxy = { value: 0 }
+
+    timeline.to(proxy, {
+      value: 1,
+      duration: 2.4,
+      ease: 'power2.out',
+      onUpdate: () => {
+        const progress = timeline.progress()
+        service.send({ type: 'TIMELINE_PROGRESS', progress })
+        emitSceneEffect({ type: 'timeline.progress', timeline: 'intro', progress })
+      },
+      onComplete: () => {
+        service.send({ type: 'INTRO_COMPLETE' })
+      },
+    })
+
+    const subscription = service.subscribe((state) => {
+      if (state.matches('intro')) {
+        if (!timeline.isActive()) {
+          timeline.restart()
+        }
+      } else if (timeline.isActive()) {
+        timeline.pause(0)
+      }
+    })
+
+    const snapshot = service.getSnapshot()
+    if (snapshot.matches('intro')) {
+      timeline.restart()
+    }
+
+    return () => {
+      subscription.unsubscribe()
+      timeline.kill()
+    }
+  }, [service])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    let rafId: number | null = null
+    let startTime = 0
+
+    const tick = (timestamp: number) => {
+      if (!startTime) {
+        startTime = timestamp
+      }
+      const duration = 900
+      const progress = Math.min(1, (timestamp - startTime) / duration)
+      emitSceneEffect({ type: 'timeline.progress', timeline: 'loading', progress })
+      rafId = window.requestAnimationFrame(tick)
+    }
+
+    const startLoop = () => {
+      if (rafId == null) {
+        startTime = 0
+        rafId = window.requestAnimationFrame(tick)
+      }
+    }
+
+    const stopLoop = () => {
+      if (rafId != null) {
+        window.cancelAnimationFrame(rafId)
+        rafId = null
+      }
+    }
+
+    const subscription = service.subscribe((state) => {
+      if (state.matches('loading')) {
+        startLoop()
+      } else {
+        stopLoop()
+      }
+    })
+
+    const snapshot = service.getSnapshot()
+    if (snapshot.matches('loading')) {
+      startLoop()
+    }
+
+    return () => {
+      stopLoop()
+      subscription.unsubscribe()
+    }
+  }, [service])
+}
+
+export function SceneStateProvider({ children }: { children: React.ReactNode }) {
+  const service = useInterpret(sceneMachine)
+
+  useSceneMachineEffects(service)
+
+  const value = useMemo(() => service, [service])
+
+  return <SceneStateContext.Provider value={value}>{children}</SceneStateContext.Provider>
+}
+
+export function useSceneService(): SceneService {
+  const service = useContext(SceneStateContext)
+  if (!service) {
+    throw new Error('useSceneService must be used within a SceneStateProvider')
+  }
+  return service
+}
+
+export function useSceneSend() {
+  return useSceneService().send
+}
+
+export function useSceneSelector<T>(selector: (state: SceneState) => T): T {
+  const service = useSceneService()
+  return useSelector(service, selector)
+}
+
+export function useSceneMode(): SceneMode {
+  return useSceneSelector((state) => resolveSceneMode(state))
+}
+
+export function useSceneValue<T>(selector: (state: SceneState) => T): T {
+  return useSceneSelector(selector)
+}
+
+export function useSceneEffect(listener: SceneEffectListener) {
+  const listenerRef = useRef(listener)
+
+  useEffect(() => {
+    listenerRef.current = listener
+  }, [listener])
+
+  useEffect(() => {
+    return onSceneEffect((effect) => {
+      listenerRef.current(effect)
+    })
+  }, [])
+}


### PR DESCRIPTION
## Summary
- introduce an xstate-driven scene state context with timeline effects for loading, intro, explore, focus, command, and build modes
- add a three-fiber based GameViewport plus intro overlay that react to scene effects for camera rails, lighting, and HUD timing
- connect App and command palette handlers to the scene machine, update HUD styling, and add required 3D/state management dependencies

## Testing
- bun install *(fails: npm registry responded with 403 while resolving new dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68fbf4a69e84832d9fca18f7af3e891f